### PR TITLE
Prefer Class.base() over goog.base()

### DIFF
--- a/oop.md
+++ b/oop.md
@@ -29,7 +29,7 @@ app.Parent.prototype.doSomething = function(param) {
  * @extends {app.Parent}
  */
 app.Child = function(foo, bar) {
-	goog.base(this, foo); // call parent constructor
+	app.Child.base(this, 'constructor', foo); // call parent constructor
 	this.bar = bar;
 };
 
@@ -44,7 +44,7 @@ app.Child.prototype.bar;
  * @override
  */
 app.Child.prototype.doSomething = function(param) {
-	goog.base(this, 'doSomething', param); // call super doSomething
+	app.Child.base(this, 'doSomething', param); // call super doSomething
 
 	// ...
 };
@@ -146,7 +146,7 @@ app.Interface.prototype.interfaceFunction;
  * @implements {app.Interface}
  */
 app.Child = function() {
-	goog.base(this);
+	app.Child.base(this, 'constructor');
 };
 
 goog.inherits(app.Child, app.AParent)
@@ -173,7 +173,7 @@ app.Child.prototype.interfaceFunction = function() {
  * @extends {goog.Disposable}
  */
 app.Foo = function() {
-	goog.base(this);
+	app.Foo.base(this, 'constructor');
 
 	// non-disposable object (NOT @extends goog.Disposable)
 	this.element = goog.dom.getElement('bar');
@@ -222,7 +222,7 @@ app.Foo.prototype.disposeInternal = function() {
 	this.handler = null;
 
 	// dispose all disposable object registered as this.registerDisposable()
-	goog.base(this, 'disposeInternal');
+	app.Foo.base(this, 'disposeInternal');
 };
 ```
 


### PR DESCRIPTION
`goog.base` is not compatible in es5 strict mode.  A replacement is available in the form of a base method added to constructors by `goog.inherit`.

The syntax is slightly different when calling from a constructor, so it is best to give an example:

Example before:

```
/** @constructor @extends {B} */
function C() {
  goog.base(this);
}
goog.inherit(C, B);

C.prototype.method = function() {
  goog.base(this, 'method');
}
```

Example after:

```
/** @constructor @extends {B} */
function C() {
  C.base(this, 'constructor');
}
goog.inherit(C, B);

C.prototype.method = function() {
  C.base(this, 'method');
}
```

Both `goog.base` and `C.base` are rewritten by the compiler when optimizations are enabled, so there are no differences in the resulting output. Please note however that `goog.base(this, 'constructor')` is **not** valid.
